### PR TITLE
Remove direct console logs from components

### DIFF
--- a/src/app/components/sidemenu/sidemenu.component.ts
+++ b/src/app/components/sidemenu/sidemenu.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, HostListener } from '@angular/core';
+import { environment } from '../../../environments/environment';
 import { CookieService } from 'angular2-cookie/core';
 import { UserIdleService } from 'angular-user-idle';
 import { Router } from '@angular/router';
@@ -38,7 +39,11 @@ export class SidemenuComponent implements OnInit {
     this.userIdle.startWatching();
     
     // Start watching when user idle is starting.
-    this.userIdle.onTimerStart().subscribe(count => console.log(count));
+    this.userIdle.onTimerStart().subscribe(count => {
+      if (!environment.production) {
+        console.log(count);
+      }
+    });
     
     // Start watch when time is up.
 

--- a/src/app/components/subheader/subheader.component.ts
+++ b/src/app/components/subheader/subheader.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { environment } from '../../../environments/environment';
 import { CookieService } from 'angular2-cookie/core';
 import { MasterDataService } from '../../services/master_data/master-data.service';
 import { ToastrService } from 'ngx-toastr';
@@ -216,7 +217,9 @@ export class SubheaderComponent implements OnInit {
 
   newNotificationsCount = 0;
   getNewNotificationsCount(data){
-    console.log(data);
+    if (!environment.production) {
+      console.log(data);
+    }
     this.academyService.getNewNotificationsCount(data).subscribe(
       (data: any) => {
         this.newNotificationsCount = data.data.count;


### PR DESCRIPTION
## Summary
- wrap console output in environment check for sidemenu and subheader

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb148e84c832f800d2762c4c7a743