### PR TITLE
Use environment variable for Google Maps API key

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { DataTableModule } from "angular-6-datatable";
 import { DataTablesModule } from 'angular-datatables';
 import { CookieService } from 'angular2-cookie/core';
 import { NgxSpinnerModule } from "ngx-spinner";
+import { environment } from '../environments/environment';
 
 
 import { HeaderComponent } from './components/header/header.component';
@@ -156,9 +157,7 @@ import { NotificationsComponent } from './components/notifications/notifications
     }), // ToastrModule added
     DataTablesModule,
     AgmCoreModule.forRoot({
-      // please get your own API key here:
-      // https://developers.google.com/maps/documentation/javascript/get-api-key?hl=en
-      apiKey: 'AIzaSyAcdenESpDJVD3v4kPYTD9rSpZqFG2spIk',
+      apiKey: environment.googleMapsApiKey,
       libraries: ['places', 'geometry']
     }),
     UserIdleModule.forRoot({idle: 1200, timeout: 300, ping: 180})
@@ -170,5 +169,4 @@ import { NotificationsComponent } from './components/notifications/notifications
 })
 export class AppModule { }
 export function cookieServiceFactory() {
-  return new CookieService();
-}
+  return new CookieService();}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   apiendpoint: 'https://www.athliosports.com/api/',
-  // apiendpoint: 'http://172.104.179.6:3000/api/'
+  // apiendpoint: 'http://172.104.179.6:3000/api/',
+  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,6 +6,7 @@ export const environment = {
   production: false,
   // apiendpoint: 'http://172.104.179.6:3000/api/',
   apiendpoint: 'http://localhost:3000/api/',
+  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY',
 };
 
 /*


### PR DESCRIPTION
## Summary
- reference `environment.googleMapsApiKey` when configuring `AgmCoreModule`
- store `googleMapsApiKey` in both environment files

## Testing
- `npm install --ignore-scripts` *(fails: dependency conflict)*
- `npm run build -- --prod` *(fails: unsupported crypto on Node 20)*

------
https://chatgpt.com/codex/tasks/task_e_686eb1450fc8832f9681a2d41ffb843b