### PR TITLE
Fix XSS risk in blogs component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -78,6 +78,7 @@ import { VgOverlayPlayModule } from 'videogular2/overlay-play';
 import { VgBufferingModule } from 'videogular2/buffering';
 import { VideosComponent } from './components/videos/videos.component';
 import { NotificationsComponent } from './components/notifications/notifications.component';
+import { SanitizeHtmlPipe } from './pipes/sanitize-html.pipe';
 @NgModule({
   declarations: [
     AppComponent,
@@ -120,6 +121,7 @@ import { NotificationsComponent } from './components/notifications/notifications
     DebounceClickDirective,
     VideosComponent,
     NotificationsComponent,
+    SanitizeHtmlPipe,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/blogs/blogs.component.html
+++ b/src/app/components/blogs/blogs.component.html
@@ -161,7 +161,7 @@
                                 <h5>Content</h5>
                                 <b>:</b>
 
-                                <span [innerHTML]="selectedBlog.content"></span>
+                                <span [innerHTML]="selectedBlog.content | sanitizeHtml"></span>
 
                             </div>
                         </div>
@@ -180,5 +180,4 @@
                 </div>
             </div>
         </div>
-    </div>
-</div>
+    </div></div>

--- a/src/app/components/blogs/blogs.component.spec.ts
+++ b/src/app/components/blogs/blogs.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BlogsComponent } from './blogs.component';
+import { SanitizeHtmlPipe } from '../../pipes/sanitize-html.pipe';
 
 describe('BlogsComponent', () => {
   let component: BlogsComponent;
@@ -8,7 +9,7 @@ describe('BlogsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BlogsComponent ]
+      declarations: [ BlogsComponent, SanitizeHtmlPipe ]
     })
     .compileComponents();
   }));
@@ -21,5 +22,13 @@ describe('BlogsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should sanitize selectedBlog content', () => {
+    component.selectedBlog = { content: '<p>Hi</p><script>alert(1)</script>' };
+    fixture.detectChanges();
+    const element: HTMLElement = fixture.nativeElement.querySelector('.about-academy-blogs span');
+    expect(element.innerHTML).toContain('<p>Hi</p>');
+    expect(element.innerHTML).not.toContain('<script>');
   });
 });

--- a/src/app/pipes/sanitize-html.pipe.spec.ts
+++ b/src/app/pipes/sanitize-html.pipe.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
+import { SanitizeHtmlPipe } from './sanitize-html.pipe';
+
+describe('SanitizeHtmlPipe', () => {
+  let pipe: SanitizeHtmlPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule]
+    });
+    const sanitizer = TestBed.inject(DomSanitizer);
+    pipe = new SanitizeHtmlPipe(sanitizer);
+  });
+
+  it('removes script tags from html', () => {
+    const html = '<p>Hello</p><script>alert(1)</script>';
+    const sanitized = pipe.transform(html);
+    expect(sanitized).toContain('<p>Hello</p>');
+    expect(sanitized).not.toContain('<script>');
+  });
+});

--- a/src/app/pipes/sanitize-html.pipe.ts
+++ b/src/app/pipes/sanitize-html.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SecurityContext } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'sanitizeHtml'
+})
+export class SanitizeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: string): string {
+    return value ? (this.sanitizer.sanitize(SecurityContext.HTML, value) || '') : '';
+  }
+}


### PR DESCRIPTION
## Summary
- sanitize blog HTML using `sanitizeHtml` pipe
- add sanitation pipe and tests
- cover sanitizing logic in unit tests

## Testing
- `npm install` *(fails: node-sass build error due to missing python and network restrictions)*
- `npm test -- --watch=false` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb14a027c832f87d87d50e1b9a348